### PR TITLE
Legacy (Depreciated v1.*) Support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,6 @@
 # LibAlexandria
 __all__ = [
     "libAlexItem",
-    "LibAlexOtherFile"
+    "libAlexOtherFile",
+    "libAlexVersionData"
 ]

--- a/libAlexItem.py
+++ b/libAlexItem.py
@@ -37,6 +37,13 @@ class LibAlexItem:
         self.flags = laShared.DEFAULT_FLAGS
         self.description = laShared.DEFAULT_DESCRIPTION
 
+    # Python Functions
+    def __str__(self) -> str:
+        if self.isLoaded:
+            return f"{self.title} by {self.author} ({self.date})"
+        else:
+            return "Invalid LibAlexandria Item"
+
     # Loader Functions
     def loadMeta(self, dirpath: str, metaFilename = "meta.json"):
         """
@@ -72,13 +79,6 @@ class LibAlexItem:
         else:
             # Failed
             print(f"Provided directory does not exist: {self.directory}")
-
-    ## Core Functions
-    def __str__(self) -> str:
-        if self.isLoaded:
-            return f"{self.title} by {self.author} ({self.date})"
-        else:
-            return "Invalid LibAlexandria Item"
 
     # Private Functions
     def _assignMetadata(self, data: dict) -> bool:

--- a/libAlexItem.py
+++ b/libAlexItem.py
@@ -29,7 +29,7 @@ class LibAlexItem:
         self.isVerbose = verbose
 
         # Prepare default values
-        self.version = None # `None` or a `VersionData` object
+        self.infoVer = None # `None` or a `VersionData` object
         self.classification = laShared.DEFAULT_CLASSIFICATION
         self.title = laShared.DEFAULT_TITLE
         self.author = laShared.DEFAULT_AUTHOR
@@ -101,9 +101,9 @@ class LibAlexItem:
 
             # Check the version
             if dataVersion.major == 2:
-                return self._parseVersionTwoData(data)
+                return self._parseVersionTwoData(data, dataVersion)
             elif dataVersion.major == 1:
-                return self._parseVersionOneData(data)
+                return self._parseVersionOneData(data, dataVersion)
             else:
                 # Failed
                 print(f"\"{dataVersion.string}\" is not a supported version of Meta file.")
@@ -114,11 +114,12 @@ class LibAlexItem:
         # Overall Failure
         return False
 
-    def _parseVersionTwoData(self, data: dict) -> bool:
+    def _parseVersionTwoData(self, data: dict, version: VersionData) -> bool:
         """
         Parses the provided Metadata JSON dictionary as a `v2.*` LibAlex dataset and assigns its values to this object.
 
         data: Metadata JSON dictionary.
+        version: A VersionData object.
 
         Returns True if the assigned metadata is valid.
         """
@@ -126,6 +127,7 @@ class LibAlexItem:
         isValid = True
 
         # Assign easy values
+        self.infoVer = version
         self.classification = data.get("classification", laShared.DEFAULT_CLASSIFICATION)
         self.title = data.get("title", laShared.DEFAULT_TITLE)
         self.author = data.get("author", laShared.DEFAULT_AUTHOR)
@@ -171,7 +173,7 @@ class LibAlexItem:
 
         return isValid
 
-    def _parseVersionOneData(self, data: dict) -> bool:
+    def _parseVersionOneData(self, data: dict, version: VersionData) -> bool:
         """
         Parses the provided Metadata JSON dictionary as a `v1.*` LibAlex dataset and assigns its values to this object the best it can.
 
@@ -179,18 +181,25 @@ class LibAlexItem:
         This is due to the fact that `v1.*` contains less information than `v2.*` data.
 
         data: Metadata JSON dictionary.
+        version: A VersionData object.
 
         Returns True if the assigned metadata is valid.
         """
         # Tell the user they're bad
         print("DEPRECATED: Version `1.*` Meta files should be converted to Version `2.*` for increased compatibility and functionality!")
 
-        # Prepare flag
-        isValid = True
+        # Convert the data to 2.*
+        translated = {
+            "title": data.get("title", laShared.DEFAULT_TITLE),
+            "author": data.get("author", laShared.DEFAULT_AUTHOR),
+            "date": data.get("date", laShared.DEFAULT_DATE),
+            "sourceFile": data.get("content", laShared.DEFAULT_SOURCEFILE),
+            "flags": data.get("flags", laShared.DEFAULT_FLAGS),
+            "description": data.get("description", laShared.DEFAULT_DESCRIPTION)
+        }
 
-        # TODO: Parse
-
-        return isValid
+        # Run through v2.* parser
+        return self._parseVersionTwoData(translated, version)
 
     # Functions
     def getAllFlags(self) -> list:

--- a/libAlexVersionData.py
+++ b/libAlexVersionData.py
@@ -35,30 +35,6 @@ class VersionData:
 
     # TODO: eq, ne, lt, le, gt, and ge functions
 
-    # def __eq__(self, __o: object) -> bool:
-    #     # Equal
-    #     return isinstance(VersionData) and (self.string == __o.string)
-
-    # def __ne__(self, __o: object) -> bool:
-    #     # Not Equal
-    #     return not (self == __o)
-
-    # def __lt__(self, __o: object) -> bool:
-    #     # Less Than
-    #     pass
-
-    # def __le__(self, other):
-    #     # Less Than or Equal To
-    #     pass
-
-    # def __gt__(self, other):
-    #     # Greater Than
-    #     pass
-
-    # def __ge__(self, other):
-    #     # Greater Than or Equat To
-    #     pass
-
     # Private Functions
     def _parse(self):
         """

--- a/libAlexVersionData.py
+++ b/libAlexVersionData.py
@@ -1,0 +1,112 @@
+# LibAlexandria: Version Data
+# Data object for comparing version numbers.
+
+# Imports
+import re
+
+# Classes
+class VersionData:
+    """
+    Interprets a basic Semantic Versioning version string like `1.0.0`.
+    """
+    # Constructor
+    def __init__(self, s: str):
+        """
+        s: A Semantic Versioning version string like `1.0.0`.
+        """
+        # Record the basic string
+        self.string = s
+
+        # Interpret the version
+        self.isValid = True
+        self.major = 0
+        self.minor = 0
+        self.patch = 0
+        self.preRelease = ""
+        self.metaData = ""
+        self._parse()
+
+    # Python Functions
+    def __str__(self) -> str:
+        return self.string
+
+    def __repr__(self) -> str:
+        return self.string
+
+    # TODO: eq, ne, lt, le, gt, and ge functions
+
+    # def __eq__(self, __o: object) -> bool:
+    #     # Equal
+    #     return isinstance(VersionData) and (self.string == __o.string)
+
+    # def __ne__(self, __o: object) -> bool:
+    #     # Not Equal
+    #     return not (self == __o)
+
+    # def __lt__(self, __o: object) -> bool:
+    #     # Less Than
+    #     pass
+
+    # def __le__(self, other):
+    #     # Less Than or Equal To
+    #     pass
+
+    # def __gt__(self, other):
+    #     # Greater Than
+    #     pass
+
+    # def __ge__(self, other):
+    #     # Greater Than or Equat To
+    #     pass
+
+    # Private Functions
+    def _parse(self):
+        """
+        Parses the version string.
+
+        Regex from https://semver.org.
+        """
+        # Collect matches
+        regex = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+        matches = re.finditer(regex, self.string, re.MULTILINE)
+
+        # Loop through matches
+        for matchNum, match in enumerate(matches, start=1):
+            # Only accept one version set
+            if matchNum > 1:
+                print(f"Multiple version code matches were found in: \"{self.string}\". Only the data from the first will be kept.")
+                break
+
+            # Get the major
+            try:
+                self.major = int(match.group(1))
+            except ValueError:
+                print(f"An invalid major version number was found in: \"{self.string}\". It will be recorded as `None`.")
+                self.major = None
+                self.isValid = False
+
+            # Get the minor
+            try:
+                self.minor = int(match.group(2))
+            except ValueError:
+                print(f"An invalid minor version number was found in: \"{self.string}\". It will be recorded as `None`.")
+                self.minor = None
+                self.isValid = False
+
+            # Get the patch
+            try:
+                self.patch = int(match.group(3))
+            except ValueError:
+                print(f"An invalid patch version number was found in: \"{self.string}\". It will be recorded as `None`.")
+                self.patch = None
+                self.isValid = False
+
+            # Get the pre-release
+            self.preRelease = match.group(4)
+
+            # Get the build meta data
+            self.metaData = match.group(5)
+
+# Console Execution
+if __name__ == "__main__":
+    print("This file cannot be run from the command line.")


### PR DESCRIPTION
* `v1.*` Meta files now load with a warning about depreciation.
* Added `VersionData` object for handling Semantic Versioning within the Meta file's `_infover` key.